### PR TITLE
Fix an infinite recursion bug on filename generation

### DIFF
--- a/upload/pomf.php
+++ b/upload/pomf.php
@@ -118,6 +118,7 @@ if ($allowed === true) {
                 $switch = true;
             } else {
                 $switch = false;
+                $fileName = generateFileName($extension);
             }
         }
 


### PR DESCRIPTION
As it is right now, a filename collision will cause an infinite recursion, leading to a timeout, causing the upload to fail.

This patch fixes that issue by regenerating a new filename when a collusion happens, until it doesn't happen. 

However, it doesn't fix the issue where you spam your own API. You should probably query your DB for that. Also, you should do the whole `isUnique` thing on `generateFileName`. I'm not going to send a PR for that as I'm not familiar enough with RL codebase and backend, but you can find our implementation of filename generation [here](https://gitlab.com/elixire/elixire/blob/master/api/common.py#L43-75).

Also on https://github.com/gtsatsis/RLAPI/pull/4